### PR TITLE
Add Anaconda details to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@
     :target: https://badge.fury.io/py/ultimate-sitemap-parser
     :alt: PyPI package
 
+.. image:: https://img.shields.io/conda/v/conda-forge/ultimate-sitemap-parser?color=brightgreen
+   :target: https://anaconda.org/conda-forge/ultimate-sitemap-parser
+   :alt: Conda
+
 .. image:: https://pepy.tech/badge/ultimate-sitemap-parser
     :target: https://pepy.tech/project/ultimate-sitemap-parser
     :alt: Download stats
@@ -50,6 +54,12 @@ Installation
 .. code:: sh
 
     pip install ultimate-sitemap-parser
+
+or using Anaconda:
+
+.. code:: sh
+
+    conda install -c conda-forge ultimate-sitemap-parser
 
 
 Usage


### PR DESCRIPTION
I've used this library as part of a research project, so to help simplify my Python environment, I've contributed a recipe for it to Conda Forge. This PR adds the installation details to the README. 

The feedstock for the package is at [conda-forge/ultimate-sitemap-parser-feedstock](https://github.com/conda-forge/ultimate-sitemap-parser-feedstock), I'm happy to update in the event this package is further updated, or can add people from mediacloud as maintainers on the repo.