### PR TITLE
add optional argument to requests web client, to ignore SSL checking

### DIFF
--- a/usp/web_client/requests_client.py
+++ b/usp/web_client/requests_client.py
@@ -75,10 +75,11 @@ class RequestsWebClient(AbstractWebClient):
         '__proxies',
     ]
 
-    def __init__(self):
+    def __init__(self, verify=True):
         self.__max_response_data_length = None
         self.__timeout = self.__HTTP_REQUEST_TIMEOUT
         self.__proxies = {}
+        self.__verify = verify
 
     def set_timeout(self, timeout: int) -> None:
         """Set HTTP request timeout."""
@@ -109,7 +110,8 @@ class RequestsWebClient(AbstractWebClient):
                 timeout=self.__timeout,
                 stream=True,
                 headers={'User-Agent': self.__USER_AGENT},
-                proxies=self.__proxies
+                proxies=self.__proxies,
+                verify=self.__verify,
             )
         except requests.exceptions.Timeout as ex:
             # Retryable timeouts


### PR DESCRIPTION
Hello -

This adds a very simple `verify` argument to the requests based web client.  You can use it pretty easily for issues like #33 by doing something like:

```python
        from usp.tree import sitemap_tree_for_homepage
        from usp.web_client.requests_client import RequestsWebClient

        client = RequestsWebClient(verify=False)  # this PR adds the verify kwarg, which defaults to True
        client.__USER_AGENT = 'Friendly Spider /{}'

        tree = sitemap_tree_for_homepage('https://nytimes.com', client)
```