### PR TITLE
Don't include invalid sitemaps in trees

### DIFF
--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1184,14 +1184,7 @@ class TestSitemapTree(TestCase):
 
             expected_sitemap_tree = IndexWebsiteSitemap(
                 url='{}/'.format(self.TEST_BASE_URL),
-                sub_sitemaps=[
-                    InvalidSitemap(
-                        url='{}/robots.txt'.format(self.TEST_BASE_URL),
-                        reason=(
-                            'Unable to fetch sitemap from {base_url}/robots.txt: 404 Not Found'
-                        ).format(base_url=self.TEST_BASE_URL),
-                    )
-                ]
+                sub_sitemaps=[],
             )
 
             actual_sitemap_tree = sitemap_tree_for_homepage(homepage_url=self.TEST_BASE_URL)

--- a/tests/web_client/test_requests_client.py
+++ b/tests/web_client/test_requests_client.py
@@ -1,3 +1,4 @@
+import re
 import socket
 from http import HTTPStatus
 from unittest import TestCase
@@ -94,7 +95,9 @@ class TestRequestsClient(TestCase):
         assert response
         assert isinstance(response, WebClientErrorResponse)
         assert response.retryable() is False
-        assert 'Failed to establish a new connection' in response.message()
+        assert re.search(
+            r'Failed to (establish a new connection|resolve)',
+            response.message()) is not None
 
     def test_get_timeout(self):
         sock = socket.socket()

--- a/usp/tree.py
+++ b/usp/tree.py
@@ -55,7 +55,8 @@ def sitemap_tree_for_homepage(homepage_url: str, web_client: Optional[AbstractWe
 
     robots_txt_fetcher = SitemapFetcher(url=robots_txt_url, web_client=web_client, recursion_level=0)
     robots_txt_sitemap = robots_txt_fetcher.sitemap()
-    sitemaps.append(robots_txt_sitemap)
+    if not isinstance(robots_txt_sitemap, InvalidSitemap):
+        sitemaps.append(robots_txt_sitemap)
 
     sitemap_urls_found_in_robots_txt = set()
     if isinstance(robots_txt_sitemap, IndexRobotsTxtSitemap):


### PR DESCRIPTION
This PR fixes two issues:
- Running ``sitemap_tree_for_homepage`` on sites with no ``/robots.txt`` returns trees containing ``InvalidSitemap`` objects.
- A test failed when run with newer versions of ``urllib3``.
